### PR TITLE
Add README with usage documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,108 @@
+# Darkhorse Aktienanalyse
+
+Dieses Projekt analysiert historische Kursdaten und erstellt einfache Kauf-, Verkaufs- oder Halteempfehlungen. Neben einer Kommandozeilenoberfläche steht ein kleiner WSGI-Webserver zur Verfügung, der die Ergebnisse im Browser visualisiert.
+
+## Voraussetzungen
+
+* Python 3.11 oder neuer
+* JSON-Dateien mit Kursdaten (siehe Abschnitt [Datenformat](#datenformat))
+
+Alle Abhängigkeiten befinden sich in der Standardbibliothek, es muss daher nichts installiert werden.
+
+## Datenformat
+
+Die Anwendung erwartet für jede WKN eine JSON-Datei mit historischen Kursen.
+
+```json
+{
+  "prices": [
+    {
+      "date": "2024-01-02T00:00:00",
+      "open": 190.82,
+      "high": 193.50,
+      "low": 189.35,
+      "close": 192.53,
+      "volume": 51234567
+    }
+  ]
+}
+```
+
+* Alternativ kann die Datei direkt eine Liste solcher Objekte enthalten.
+* `date` muss ein ISO-8601 Datum (mit Uhrzeit) sein. Die Einträge werden automatisch nach Datum sortiert.
+* `open`, `high`, `low` und `close` sind Pflichtfelder.
+* `volume` ist optional und kann weggelassen oder als `null` angegeben werden.
+
+Standardmäßig sucht die Anwendung Kursdaten in `data/<WKN>.json`.
+
+## Watchlists und WKN-Angaben
+
+Für die Analyse können WKNs direkt auf der Kommandozeile übergeben oder aus einer Watchlist geladen werden.
+
+**Direkte Angabe**
+
+```
+python -m app.main --wkn US0378331005
+```
+
+Optional lässt sich ein alternativer Pfad zur Kursdatei angeben:
+
+```
+python -m app.main --wkn US0378331005=/pfad/zu/apple.json
+```
+
+**Watchlist-Dateien**
+
+Watchlists sind JSON-Dateien, die entweder eine Liste oder ein Objekt enthalten dürfen:
+
+```json
+[
+  "US0378331005",
+  { "wkn": "DE0007664039", "path": "../daten/vw.json" }
+]
+```
+
+```json
+{
+  "US0378331005": null,
+  "DE0007664039": "../daten/vw.json"
+}
+```
+
+Relative Pfade werden relativ zum Speicherort der Watchlist aufgelöst.
+
+## Kommandozeilenoberfläche
+
+Die CLI liest historische Daten ein, prüft ob genügend Historie vorliegt und gibt anschließend eine Empfehlung samt Begründung aus.
+
+```
+python -m app.main --watchlist watchlists/beobachtungsliste.json --min-history 60
+```
+
+Verfügbare Optionen:
+
+* `--wkn`: WKN mit optionalem Pfad zur Kursdatei (`WKN=pfad`). Kann mehrfach angegeben werden.
+* `--watchlist`: Pfad zu einer JSON-Watchlist.
+* `--min-history`: Minimale Anzahl an Handelstagen (Standard 60).
+
+Der Exit-Code ist `0` bei Erfolg und `1`, wenn eine oder mehrere WKNs nicht verarbeitet werden konnten.
+
+## Weboberfläche
+
+Der Webserver stellt dieselben Daten wie die CLI dar, jedoch in einer kartenbasierten Übersicht im Browser.
+
+```
+python -m app.web --watchlist watchlists/beobachtungsliste.json --port 8000
+```
+
+* Nach dem Start ist die Oberfläche unter `http://127.0.0.1:8000` erreichbar.
+* Weitere WKNs können per Query-Parameter hinzugefügt werden, z. B. `http://127.0.0.1:8000/?wkn=US0378331005`.
+* Mit `Strg+C` wird der Server beendet.
+
+## Beispiel-Daten
+
+Im Ordner `data/` befindet sich eine Beispiel-Datei (`US0378331005.json`) für Apple. `watchlists/beobachtungsliste.json` zeigt die erlaubten Watchlist-Formate.
+
+## Entwicklung & Tests
+
+Für manuelle Tests können Sie die oben genannten Befehle verwenden. Automatisierte Tests sind momentan nicht eingerichtet.

--- a/app/main.py
+++ b/app/main.py
@@ -3,20 +3,13 @@
 from __future__ import annotations
 
 import argparse
-import json
 import sys
 from pathlib import Path
 from typing import Iterable, List, Sequence
 
 from .data import load_price_history, most_recent_date, validate_enough_data
 from .recommender import analyse_stock
-
-
-def _parse_wkn_argument(argument: str) -> tuple[str, Path]:
-    if "=" in argument:
-        wkn, _, path = argument.partition("=")
-        return wkn.strip(), Path(path.strip())
-    return argument.strip(), Path(f"data/{argument.strip()}.json")
+from .specs import collect_specs
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -51,77 +44,12 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Minimale Anzahl an Handelstagen für eine Auswertung (Standard: 60).",
     )
     return parser
-
-
-def _load_watchlist(path: Path) -> List[tuple[str, Path]]:
-    """Parse watchlist entries from a JSON file."""
-
-    with path.open("r", encoding="utf-8") as handle:
-        payload = json.load(handle)
-
-    entries: list[tuple[str, Path]] = []
-
-    def _append_entry(raw_wkn: str, raw_path: str | None) -> None:
-        wkn = str(raw_wkn).strip()
-        if not wkn:
-            raise ValueError("Watchlist-Eintrag ohne WKN gefunden")
-
-        resolved_path: Path
-        if raw_path:
-            candidate = Path(str(raw_path).strip())
-            if not candidate.is_absolute():
-                candidate = path.parent / candidate
-            resolved_path = candidate
-        else:
-            resolved_path = Path(f"data/{wkn}.json")
-
-        entries.append((wkn, resolved_path))
-
-    if isinstance(payload, list):
-        for index, item in enumerate(payload):
-            if isinstance(item, str):
-                _append_entry(item, None)
-            elif isinstance(item, dict):
-                _append_entry(item.get("wkn", ""), item.get("path"))
-            else:
-                raise ValueError(
-                    f"Watchlist-Eintrag an Position {index} hat ein unbekanntes Format"
-                )
-    elif isinstance(payload, dict):
-        for wkn, raw_path in payload.items():
-            if raw_path is None or isinstance(raw_path, str):
-                _append_entry(wkn, raw_path)
-            else:
-                raise ValueError(
-                    f"Watchlist-Eintrag für {wkn} hat ein unbekanntes Format"
-                )
-    else:
-        raise ValueError("Watchlist-Datei muss eine Liste oder ein Objekt enthalten")
-
-    return entries
-
-
-def _collect_specs(
-    direct_specs: Sequence[str] | None, watchlist_path: Path | None
-) -> List[tuple[str, Path]]:
-    specs: list[tuple[str, Path]] = []
-
-    if watchlist_path is not None:
-        specs.extend(_load_watchlist(watchlist_path))
-
-    if direct_specs:
-        for spec in direct_specs:
-            specs.append(_parse_wkn_argument(spec))
-
-    return specs
-
-
 def main(argv: Iterable[str] | None = None) -> int:
     parser = _build_parser()
     args = parser.parse_args(argv)
 
     try:
-        specs = _collect_specs(args.wkn, args.watchlist)
+        specs = collect_specs(args.wkn, args.watchlist)
     except FileNotFoundError:
         parser.error(f"Watchlist-Datei {args.watchlist} wurde nicht gefunden.")
     except ValueError as exc:

--- a/app/specs.py
+++ b/app/specs.py
@@ -1,0 +1,83 @@
+"""Utilities for parsing watchlists and WKN specifications."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List, Sequence, Tuple
+import json
+
+
+WknSpec = Tuple[str, Path]
+
+
+def parse_wkn_argument(argument: str) -> WknSpec:
+    """Return the WKN and optional path encoded in an argument string."""
+
+    if "=" in argument:
+        wkn, _, raw_path = argument.partition("=")
+        return wkn.strip(), Path(raw_path.strip())
+    return argument.strip(), Path(f"data/{argument.strip()}.json")
+
+
+def load_watchlist(path: Path) -> List[WknSpec]:
+    """Parse watchlist entries from the provided JSON file."""
+
+    with path.open("r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+
+    entries: list[WknSpec] = []
+
+    def _append_entry(raw_wkn: str, raw_path: str | None) -> None:
+        wkn = str(raw_wkn).strip()
+        if not wkn:
+            raise ValueError("Watchlist-Eintrag ohne WKN gefunden")
+
+        if raw_path:
+            candidate = Path(str(raw_path).strip())
+            if not candidate.is_absolute():
+                candidate = path.parent / candidate
+            resolved_path = candidate
+        else:
+            resolved_path = Path(f"data/{wkn}.json")
+
+        entries.append((wkn, resolved_path))
+
+    if isinstance(payload, list):
+        for index, item in enumerate(payload):
+            if isinstance(item, str):
+                _append_entry(item, None)
+            elif isinstance(item, dict):
+                _append_entry(item.get("wkn", ""), item.get("path"))
+            else:
+                raise ValueError(
+                    f"Watchlist-Eintrag an Position {index} hat ein unbekanntes Format"
+                )
+    elif isinstance(payload, dict):
+        for wkn, raw_path in payload.items():
+            if raw_path is None or isinstance(raw_path, str):
+                _append_entry(wkn, raw_path)
+            else:
+                raise ValueError(
+                    f"Watchlist-Eintrag für {wkn} hat ein unbekanntes Format"
+                )
+    else:
+        raise ValueError("Watchlist-Datei muss eine Liste oder ein Objekt enthalten")
+
+    return entries
+
+
+def collect_specs(
+    direct_specs: Sequence[str] | None, watchlist_path: Path | None
+) -> List[WknSpec]:
+    """Combine direct WKN arguments and optional watchlist entries."""
+
+    specs: list[WknSpec] = []
+
+    if watchlist_path is not None:
+        specs.extend(load_watchlist(watchlist_path))
+
+    if direct_specs:
+        for spec in direct_specs:
+            specs.append(parse_wkn_argument(spec))
+
+    return specs

--- a/app/web.py
+++ b/app/web.py
@@ -1,0 +1,236 @@
+"""Simple web interface to inspect prices and recommendations."""
+
+from __future__ import annotations
+
+import argparse
+import html
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable, List, Sequence
+from urllib.parse import parse_qs
+from wsgiref.simple_server import make_server
+
+from .data import load_price_history, most_recent_date, validate_enough_data
+from .recommender import Recommendation, analyse_stock
+from .specs import WknSpec, collect_specs, parse_wkn_argument
+
+
+@dataclass(frozen=True)
+class DisplayEntry:
+    """Container for information rendered in the HTML page."""
+
+    wkn: str
+    latest_date: datetime | None
+    recommendation: Recommendation
+    recent_bars: List[tuple[datetime, float]]
+
+
+def _prepare_entries(specs: Sequence[WknSpec], minimum_history: int) -> tuple[List[DisplayEntry], List[str]]:
+    entries: list[DisplayEntry] = []
+    errors: list[str] = []
+
+    for wkn, path in specs:
+        try:
+            history = load_price_history(path)
+            validate_enough_data(history, minimum_history)
+            recommendation = analyse_stock(wkn, history)
+        except FileNotFoundError:
+            errors.append(f"{wkn}: Keine Kursdaten gefunden – erwartete Datei {path}")
+            continue
+        except ValueError as exc:
+            errors.append(f"{wkn}: {exc}")
+            continue
+
+        latest = most_recent_date(history)
+        recent = [(bar.date, bar.close) for bar in history[-10:]]
+        entries.append(
+            DisplayEntry(
+                wkn=wkn,
+                latest_date=latest,
+                recommendation=recommendation,
+                recent_bars=recent,
+            )
+        )
+
+    entries.sort(key=lambda entry: entry.wkn)
+    return entries, errors
+
+
+def _format_date(value: datetime | None) -> str:
+    if value is None:
+        return "–"
+    return value.date().isoformat()
+
+
+def _render_html(entries: Sequence[DisplayEntry], errors: Sequence[str]) -> str:
+    parts: list[str] = [
+        "<!DOCTYPE html>",
+        "<html lang='de'>",
+        "<head>",
+        "  <meta charset='utf-8'>",
+        "  <title>Aktienübersicht</title>",
+        "  <style>",
+        "    body { font-family: system-ui, sans-serif; margin: 2rem; background: #f5f5f5; color: #222; }",
+        "    h1 { margin-bottom: 1rem; }",
+        "    .grid { display: grid; gap: 1.5rem; grid-template-columns: repeat(auto-fit, minmax(22rem, 1fr)); }",
+        "    .card { background: white; border-radius: 0.75rem; padding: 1.5rem; box-shadow: 0 0.5rem 1.5rem rgba(0,0,0,0.08); }",
+        "    .card h2 { margin-top: 0; font-size: 1.3rem; }",
+        "    .recommendation { font-weight: bold; margin: 0.5rem 0; }",
+        "    .confidence { color: #666; font-size: 0.9rem; }",
+        "    ul { padding-left: 1.2rem; }",
+        "    table { width: 100%; border-collapse: collapse; margin-top: 1rem; font-size: 0.9rem; }",
+        "    th, td { border-bottom: 1px solid #ddd; padding: 0.3rem 0.4rem; text-align: left; }",
+        "    th { color: #555; font-weight: 600; }",
+        "    .errors { background: #ffecec; border: 1px solid #f5a3a3; color: #a40000; padding: 1rem; border-radius: 0.75rem; margin-bottom: 1.5rem; }",
+        "  </style>",
+        "</head>",
+        "<body>",
+        "  <h1>Kurse &amp; Empfehlungen</h1>",
+    ]
+
+    if errors:
+        parts.append("  <section class='errors'>")
+        parts.append("    <h2>Fehler beim Laden</h2>")
+        parts.append("    <ul>")
+        for message in errors:
+            parts.append(f"      <li>{html.escape(message)}</li>")
+        parts.append("    </ul>")
+        parts.append("  </section>")
+
+    parts.append("  <section class='grid'>")
+    for entry in entries:
+        recommendation = entry.recommendation
+        parts.append("    <article class='card'>")
+        parts.append(f"      <h2>{html.escape(entry.wkn)}</h2>")
+        parts.append(
+            f"      <p class='recommendation'>Empfehlung: {html.escape(recommendation.action)} "
+            f"<span class='confidence'>(Konfidenz {recommendation.confidence:.2f})</span></p>"
+        )
+        parts.append(f"      <p>Letzter Handelstag: {_format_date(entry.latest_date)}</p>")
+        parts.append("      <h3>Begründungen</h3>")
+        parts.append("      <ul>")
+        for reason in recommendation.reasons:
+            parts.append(f"        <li>{html.escape(reason)}</li>")
+        parts.append("      </ul>")
+        parts.append("      <h3>Letzte Schlusskurse</h3>")
+        parts.append("      <table>")
+        parts.append("        <thead><tr><th>Datum</th><th>Schluss</th></tr></thead>")
+        parts.append("        <tbody>")
+        for date_value, close in entry.recent_bars[::-1]:
+            parts.append(
+                "          <tr><td>"
+                + html.escape(date_value.date().isoformat())
+                + "</td><td>"
+                + html.escape(f"{close:.2f}")
+                + "</td></tr>"
+            )
+        parts.append("        </tbody>")
+        parts.append("      </table>")
+        parts.append("    </article>")
+    parts.append("  </section>")
+    parts.append("</body>")
+    parts.append("</html>")
+
+    return "\n".join(parts)
+
+
+def create_app(default_specs: Sequence[WknSpec], minimum_history: int):
+    """Create a WSGI application that renders the overview page."""
+
+    default_specs = list(default_specs)
+
+    def app(environ, start_response):  # type: ignore[override]
+        query = parse_qs(environ.get("QUERY_STRING", ""))
+        if "wkn" in query:
+            specs: list[WknSpec] = []
+            for raw in query.get("wkn", []):
+                if raw:
+                    specs.append(parse_wkn_argument(raw))
+        else:
+            specs = list(default_specs)
+
+        entries, errors = _prepare_entries(specs, minimum_history)
+        html_body = _render_html(entries, errors)
+        payload = html_body.encode("utf-8")
+
+        start_response(
+            "200 OK",
+            [
+                ("Content-Type", "text/html; charset=utf-8"),
+                ("Content-Length", str(len(payload))),
+            ],
+        )
+        return [payload]
+
+    return app
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Startet einen kleinen Webserver, der Kurse und Empfehlungen für die "
+            "angegebenen Wertpapiere anzeigt."
+        )
+    )
+    parser.add_argument("--host", default="127.0.0.1", help="Adresse, an die gebunden wird (Standard: 127.0.0.1)")
+    parser.add_argument("--port", type=int, default=8000, help="Port für den Webserver (Standard: 8000)")
+    parser.add_argument(
+        "--wkn",
+        action="append",
+        help=(
+            "Wertpapierkennnummer mit optionalem Pfad zur JSON-Datei. "
+            "Beispiel: DE0001234567=data/meine_daten.json. Ohne Pfad wird data/<WKN>.json erwartet."
+        ),
+    )
+    parser.add_argument(
+        "--watchlist",
+        type=Path,
+        help=(
+            "Pfad zu einer JSON-Datei mit mehreren WKN-Einträgen. Einträge können als Liste von Strings oder Objekten mit den "
+            "Schlüsseln 'wkn' und optional 'path' angegeben werden."
+        ),
+    )
+    parser.add_argument(
+        "--min-history",
+        type=int,
+        default=60,
+        help="Minimale Anzahl an Handelstagen für eine Auswertung (Standard: 60).",
+    )
+    return parser
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        specs = collect_specs(args.wkn, args.watchlist)
+    except FileNotFoundError:
+        parser.error(f"Watchlist-Datei {args.watchlist} wurde nicht gefunden.")
+    except ValueError as exc:
+        parser.error(str(exc))
+        return 2
+
+    if not specs:
+        parser.error(
+            "Es wurde keine WKN angegeben. Verwenden Sie --wkn oder --watchlist."
+        )
+        return 2
+
+    app = create_app(specs, args.min_history)
+
+    with make_server(args.host, args.port, app) as server:
+        print(
+            f"Server gestartet auf http://{server.server_address[0]}:{server.server_address[1]} "
+            "– drücken Sie Strg+C zum Beenden."
+        )
+        try:
+            server.serve_forever()
+        except KeyboardInterrupt:
+            print("Server wird beendet...")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- document Projektüberblick, erwartetes Datenformat und Watchlist-Varianten in einer README
- beschreibe Aufrufoptionen der CLI sowie des Webservers und verweise auf Beispieldateien

## Testing
- `python -m app.main --help`
- `python -m app.web --help`


------
https://chatgpt.com/codex/tasks/task_e_68d447c3b5d4832d8a077dd0b6ab9174