### PR TITLE
Add KuCoin data downloader and integrate into live demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,10 +53,27 @@ Projekt nun ein dünnes Kompatibilitätspaket bereit, das alle Funktionen an die
 neuen `darkhorse`-Module weiterreicht. Für neue Installationen wird dennoch die
 Verwendung des Namens `darkhorse` empfohlen.
 
+### KuCoin-Daten abrufen
+
+Für realistische Simulationen sowie als Grundlage für die Live-Demo können
+historische Kurse direkt von KuCoin geladen werden. Das Projekt liefert dazu den
+kleinen Helfer ``python -m darkhorse.kucoin``. Mit folgendem Befehl werden zum
+Beispiel zwei Jahre an 1-Stunden-Kerzen für das Handelspaar XMR/USDT in die
+Datei ``data/xmr-kucoin-1hour.json`` geschrieben:
+
+```
+python -m darkhorse.kucoin --years 2 --interval 1hour --output data/xmr-kucoin-1hour.json
+```
+
+Die erzeugte Datei kann sowohl mit ``--data`` an die CLI- und Web-Anwendungen
+übergeben als auch von der Live-Demo für Offline-Simulationen genutzt werden.
+Sollte kein Internetzugang vorhanden sein, bleibt weiterhin die mitgelieferte
+``data/monero.json`` als Fallback verfügbar.
+
 ### Live-Trading-Demo
 
 Wer statt historischer Daten den aktuellen Markt beobachten möchte, kann die
-Live-Demo starten. Sie lädt jede Minute aktuelle XMR/USD-Kurse von CoinGecko,
+Live-Demo starten. Sie lädt jede Minute aktuelle XMR/USD-Kurse von KuCoin,
 
 wendet die Analyse darauf an und schichtet – abhängig von der ermittelten
 Konfidenz – nur einen Teil des Bestands zwischen XMR und USD um. So bleibt das
@@ -65,9 +82,9 @@ beginnt die Demo mit **1 XMR** und keinem USD.
 
 
 Sollte kein Internetzugang zur Verfügung stehen, simuliert die Demo automatisch
-synthetische Minutenkerzen auf Basis der mitgelieferten historischen Daten. So
-bleibt das Skript funktionsfähig, selbst wenn die CoinGecko-API nicht erreichbar
-ist.
+synthetische Minutenkerzen auf Basis der KuCoin-Daten (sofern heruntergeladen)
+oder der mitgelieferten historischen Daten. So bleibt das Skript funktionsfähig,
+selbst wenn die KuCoin-API nicht erreichbar ist.
 
 ```
 

--- a/darkhorse/kucoin.py
+++ b/darkhorse/kucoin.py
@@ -1,0 +1,373 @@
+"""Utility helpers to download historical Monero data from KuCoin.
+
+The live trading demo can make use of a local cache with historical price
+information.  Because this repository should run in isolated environments we do
+not ship a large dataset with it.  Instead this module provides a tiny command
+line helper that downloads the required information from the public KuCoin API
+and stores it in the JSON layout understood by :mod:`darkhorse.data`.
+
+Typical usage::
+
+    python -m darkhorse.kucoin --years 2 --interval 1hour --output data/xmr-kucoin-1h.json
+
+The command will query the KuCoin REST endpoint in chunks, convert the returned
+candles to :class:`~darkhorse.data.PriceBar` compatible dictionaries and write
+them to ``output``.  The resulting file can then be supplied to the main
+``darkhorse`` commands via ``--data`` or used by the trading demo as
+simulation source.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import time
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Iterable, Iterator, List, Sequence
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode
+from urllib.request import urlopen
+
+from .data import PriceBar
+
+
+_API_URL = "https://api.kucoin.com/api/v1/market/candles"
+
+
+# Mapping taken from the KuCoin API documentation.  The platform restricts the
+# number of records per response to at most 1500 candles.  Knowing the duration
+# of each candle allows us to iteratively request large time ranges without
+# missing data.
+_INTERVAL_SECONDS: dict[str, int] = {
+    "1min": 60,
+    "3min": 180,
+    "5min": 300,
+    "15min": 900,
+    "30min": 1_800,
+    "1hour": 3_600,
+    "2hour": 7_200,
+    "4hour": 14_400,
+    "6hour": 21_600,
+    "8hour": 28_800,
+    "12hour": 43_200,
+    "1day": 86_400,
+    "1week": 604_800,
+}
+
+
+class KuCoinError(RuntimeError):
+    """Raised when interaction with the KuCoin API fails."""
+
+
+@dataclass(frozen=True)
+class KuCoinCandle:
+    """Representation of a single KuCoin candle entry."""
+
+    timestamp: datetime
+    open: float
+    close: float
+    high: float
+    low: float
+    volume: float | None
+
+    def as_price_bar(self) -> PriceBar:
+        return PriceBar(
+            date=self.timestamp,
+            open=self.open,
+            high=self.high,
+            low=self.low,
+            close=self.close,
+            volume=self.volume,
+        )
+
+
+def _request_candles(
+    symbol: str,
+    interval: str,
+    start_at: int,
+    end_at: int,
+) -> Sequence[Sequence[str]]:
+    """Perform a single HTTP request against the KuCoin candle endpoint."""
+
+    query = urlencode(
+        {
+            "type": interval,
+            "symbol": symbol,
+            "startAt": start_at,
+            "endAt": end_at,
+        }
+    )
+    url = f"{_API_URL}?{query}"
+
+    try:
+        with urlopen(url, timeout=20) as response:  # type: ignore[arg-type]
+            payload = response.read()
+    except (HTTPError, URLError) as exc:  # pragma: no cover - depends on network
+        raise KuCoinError(f"HTTP request to KuCoin failed: {exc}") from exc
+
+    try:
+        data = json.loads(payload)
+    except json.JSONDecodeError as exc:  # pragma: no cover - malformed payloads
+        raise KuCoinError("Could not decode KuCoin response as JSON") from exc
+
+    if not isinstance(data, dict):
+        raise KuCoinError("Unexpected JSON structure returned by KuCoin API")
+
+    if data.get("code") != "200000":
+        raise KuCoinError(f"KuCoin API returned error code: {data.get('code')!r}")
+
+    candles = data.get("data")
+    if candles is None:
+        return []
+    if not isinstance(candles, list):
+        raise KuCoinError("KuCoin API returned unexpected data format")
+    # The response is documented to be sorted from most recent to oldest.  We
+    # keep the raw order here and let the caller re-arrange if needed.
+    return [candle for candle in candles if isinstance(candle, list)]
+
+
+def _parse_candle(raw: Sequence[str]) -> KuCoinCandle:
+    if len(raw) < 5:
+        raise KuCoinError(f"Candle entry contains too few elements: {raw!r}")
+
+    try:
+        timestamp = datetime.fromtimestamp(float(raw[0]), tz=timezone.utc)
+        open_price = float(raw[1])
+        close_price = float(raw[2])
+        high_price = float(raw[3])
+        low_price = float(raw[4])
+    except (TypeError, ValueError) as exc:
+        raise KuCoinError(f"Invalid numerical value in candle entry {raw!r}") from exc
+
+    volume: float | None = None
+    if len(raw) >= 6:
+        try:
+            volume_value = float(raw[5])
+        except (TypeError, ValueError):
+            volume_value = math.nan
+        if math.isfinite(volume_value):
+            volume = volume_value
+
+    return KuCoinCandle(timestamp, open_price, close_price, high_price, low_price, volume)
+
+
+def iter_candles(
+    symbol: str,
+    interval: str,
+    start: datetime,
+    end: datetime,
+    *,
+    batch_sleep: float = 0.2,
+    batch_size: int = 1_500,
+) -> Iterator[KuCoinCandle]:
+    """Yield candles for ``symbol`` between ``start`` and ``end`` (inclusive)."""
+
+    if interval not in _INTERVAL_SECONDS:
+        raise KuCoinError(f"Unsupported interval {interval!r}")
+
+    interval_seconds = _INTERVAL_SECONDS[interval]
+    start_ts = int(start.replace(tzinfo=timezone.utc).timestamp())
+    end_ts = int(end.replace(tzinfo=timezone.utc).timestamp())
+
+    if start_ts >= end_ts:
+        raise KuCoinError("start must be earlier than end")
+
+    # KuCoin returns results in descending order.  We fetch in chunks moving the
+    # window forward to avoid requesting overlapping slices.
+    cursor = start_ts
+    while cursor < end_ts:
+        window_end = min(end_ts, cursor + interval_seconds * batch_size)
+        raw_candles = _request_candles(symbol, interval, cursor, window_end)
+
+        if not raw_candles:
+            cursor = window_end + interval_seconds
+            continue
+
+        # We iterate the response in reverse order so that consumers receive
+        # candles sorted by timestamp in ascending order.
+        for raw_candle in reversed(raw_candles):
+            candle = _parse_candle(raw_candle)
+            if candle.timestamp < datetime.fromtimestamp(cursor, tz=timezone.utc):
+                continue
+            if candle.timestamp > datetime.fromtimestamp(end_ts, tz=timezone.utc):
+                continue
+            yield candle
+
+        last_timestamp = raw_candles[0][0]
+        try:
+            cursor = int(float(last_timestamp)) + interval_seconds
+        except (TypeError, ValueError):
+            cursor = window_end + interval_seconds
+
+        if batch_sleep:
+            time.sleep(batch_sleep)  # pragma: no cover - slow path for politeness
+
+
+def collect_price_bars(
+    symbol: str,
+    interval: str,
+    start: datetime,
+    end: datetime,
+    *,
+    batch_sleep: float = 0.2,
+    batch_size: int = 1_500,
+) -> List[PriceBar]:
+    """Return a list of :class:`PriceBar` entries for the requested range."""
+
+    candles = list(
+        iter_candles(
+            symbol,
+            interval,
+            start,
+            end,
+            batch_sleep=batch_sleep,
+            batch_size=batch_size,
+        )
+    )
+    bars = [candle.as_price_bar() for candle in candles]
+    bars.sort(key=lambda bar: bar.date)
+    return bars
+
+
+def _serialize_bars(bars: Iterable[PriceBar]) -> list[dict[str, object]]:
+    serialised: list[dict[str, object]] = []
+    for bar in bars:
+        serialised.append(
+            {
+                "date": bar.date.isoformat(),
+                "open": bar.open,
+                "high": bar.high,
+                "low": bar.low,
+                "close": bar.close,
+                "volume": bar.volume,
+            }
+        )
+    return serialised
+
+
+def _default_output_path(interval: str) -> Path:
+    filename = f"xmr-kucoin-{interval}.json"
+    return Path("data") / filename
+
+
+def _build_argument_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Lädt historische Kurse von KuCoin herunter und speichert sie im "
+            "JSON-Format des Projekts."
+        )
+    )
+    parser.add_argument(
+        "--symbol",
+        default="XMR-USDT",
+        help="Handelspaar, das abgerufen werden soll (Standard: %(default)s).",
+    )
+    parser.add_argument(
+        "--interval",
+        default="1hour",
+        choices=sorted(_INTERVAL_SECONDS.keys()),
+        help="Kerzenintervall, z.B. 1min, 1hour oder 1day (Standard: %(default)s).",
+    )
+    parser.add_argument(
+        "--years",
+        type=float,
+        default=2.0,
+        help=(
+            "Wie viele Jahre historischer Daten geladen werden sollen. "
+            "Kann nicht zusammen mit --start genutzt werden (Standard: %(default)s)."
+        ),
+    )
+    parser.add_argument(
+        "--start",
+        type=_parse_iso_datetime,
+        help="Optionaler Startzeitpunkt im ISO-Format (z.B. 2022-01-01T00:00:00).",
+    )
+    parser.add_argument(
+        "--end",
+        type=_parse_iso_datetime,
+        default=lambda: datetime.now(tz=timezone.utc),
+        help="Optionaler Endzeitpunkt im ISO-Format (Standard: aktuelle Zeit).",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="Zieldatei für die Kursdaten (Standard: data/xmr-kucoin-<interval>.json).",
+    )
+    parser.add_argument(
+        "--no-sleep",
+        action="store_true",
+        help=(
+            "Verzichtet auf kurze Pausen zwischen API-Aufrufen. Dies beschleunigt "
+            "Downloads, kann aber zu Rate-Limits führen."
+        ),
+    )
+    return parser
+
+
+def _parse_iso_datetime(value: str) -> datetime:
+    try:
+        return datetime.fromisoformat(value).astimezone(timezone.utc)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"Ungültiges Datum {value!r}: {exc}") from exc
+
+
+def _resolve_time_range(
+    start: datetime | None,
+    end: datetime | None,
+    years: float,
+) -> tuple[datetime, datetime]:
+    resolved_end = end or datetime.now(tz=timezone.utc)
+    if start is None:
+        resolved_start = resolved_end - timedelta(days=365 * years)
+    else:
+        resolved_start = start
+
+    if resolved_start >= resolved_end:
+        raise KuCoinError("Startzeitpunkt muss vor dem Endzeitpunkt liegen")
+    return resolved_start, resolved_end
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    parser = _build_argument_parser()
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    end = args.end() if callable(args.end) else args.end
+    start, end = _resolve_time_range(args.start, end, args.years)
+
+    batch_sleep = 0.0 if args.no_sleep else 0.2
+
+    try:
+        bars = collect_price_bars(
+            args.symbol,
+            args.interval,
+            start,
+            end,
+            batch_sleep=batch_sleep,
+        )
+    except KuCoinError as exc:
+        parser.error(str(exc))
+        return 2  # pragma: no cover - error path after parser.error
+
+    output_path = args.output or _default_output_path(args.interval)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    payload = {"prices": _serialize_bars(bars)}
+    with output_path.open("w", encoding="utf-8") as fp:
+        json.dump(payload, fp, indent=2)
+        fp.write("\n")
+
+    print(
+        "Gespeicherte KuCoin-Daten:",
+        output_path,
+        f"({len(bars)} Kerzen, {args.interval})",
+        flush=True,
+    )
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - manual usage
+    raise SystemExit(main())
+

--- a/darkhorse/live.py
+++ b/darkhorse/live.py
@@ -1,36 +1,25 @@
-
 """Utilities to fetch live Monero pricing data from public APIs.
 
 In isolated environments without internet access the live API cannot be
 reached. To keep the demo applications operational we therefore offer a
 light-weight simulation that replays historical Monero prices and maps them
 onto a synthetic minute timeline. The trading CLI can seamlessly fall back to
-this simulator when network requests fail.
-"""
+this simulator when network requests fail."""
 
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-
-from typing import Any, List
-from urllib.error import URLError, HTTPError
-from urllib.request import urlopen
-import json
+from typing import List
 
 from .data import PriceBar, load_price_history
+from .kucoin import KuCoinError, collect_price_bars
 
-
-# CoinGecko offers free access to market data without the need for API keys.
-# We rely on the minute resolution endpoint which returns up to 24 hours of
-# price history.  The returned payload is a mapping with the key "prices"
-# whose values are pairs of ``[timestamp, price]``.
-_MARKET_CHART_URL = (
-    "https://api.coingecko.com/api/v3/coins/monero/market_chart"
-    "?vs_currency=usd&days=1&interval=minute"
-)
 
 _SIMULATION_DATA = Path(__file__).resolve().parent.parent / "data" / "monero.json"
+_KUCOIN_SIMULATION_DATA = (
+    Path(__file__).resolve().parent.parent / "data" / "xmr-kucoin-1hour.json"
+)
 
 
 class LiveDataError(RuntimeError):
@@ -44,7 +33,9 @@ class SimulatedMoneroFeed:
         if limit <= 0:
             raise ValueError("limit must be positive")
 
-        dataset = history_path or _SIMULATION_DATA
+        dataset = history_path or (
+            _KUCOIN_SIMULATION_DATA if _KUCOIN_SIMULATION_DATA.exists() else _SIMULATION_DATA
+        )
         try:
             source = load_price_history(dataset)
         except (OSError, ValueError) as exc:
@@ -113,61 +104,24 @@ class SimulatedMoneroFeed:
             self._history = self._history[-self._limit :]
         return list(self._history)
 
-def _fetch_json(url: str) -> Any:
-    try:
-        with urlopen(url, timeout=15) as response:  # type: ignore[arg-type]
-            if response.status != 200:
-                raise LiveDataError(f"Unexpected status code {response.status} from API")
-            payload = response.read()
-    except (HTTPError, URLError) as exc:  # pragma: no cover - depends on network
-        raise LiveDataError(f"Could not download live data: {exc}") from exc
-
-    try:
-        return json.loads(payload)
-    except json.JSONDecodeError as exc:  # pragma: no cover - malformed data
-        raise LiveDataError("Received malformed JSON payload from API") from exc
-
 
 def fetch_monero_minute_bars(limit: int = 240) -> List[PriceBar]:
-    """Return recent minute candles for Monero priced in USD.
+    """Return recent minute candles for Monero priced in USD."""
 
-    Parameters
-    ----------
-    limit:
-        Maximum number of minute bars to return. The API yields up to 24 hours
-        of data; the latest ``limit`` entries are used to keep calculations
-        efficient.
-    """
+    if limit <= 0:
+        raise LiveDataError("limit must be positive")
 
-    payload = _fetch_json(_MARKET_CHART_URL)
-    prices = payload.get("prices")
-    if not isinstance(prices, list):
-        raise LiveDataError("API response does not contain a 'prices' list")
+    end = datetime.now(timezone.utc)
+    # Request slightly more data than necessary to cope with short gaps.
+    start = end - timedelta(minutes=max(limit * 2, 10))
 
-    bars: List[PriceBar] = []
-    for entry in prices[-limit:]:
-        if not isinstance(entry, list) or len(entry) != 2:
-            raise LiveDataError("Unexpected price entry structure in API response")
-        timestamp_ms, price = entry
-        try:
-            timestamp = datetime.fromtimestamp(float(timestamp_ms) / 1000.0, tz=timezone.utc)
-            price_value = float(price)
-        except (TypeError, ValueError) as exc:
-            raise LiveDataError("Invalid timestamp or price value in API response") from exc
-
-        bars.append(
-            PriceBar(
-                date=timestamp,
-                open=price_value,
-                high=price_value,
-                low=price_value,
-                close=price_value,
-                volume=None,
-            )
-        )
+    try:
+        bars = collect_price_bars("XMR-USDT", "1min", start, end)
+    except KuCoinError as exc:  # pragma: no cover - depends on network
+        raise LiveDataError(f"Konnte KuCoin-Daten nicht laden: {exc}") from exc
 
     if not bars:
-        raise LiveDataError("API response did not return any price entries")
+        raise LiveDataError("KuCoin API lieferte keine Kursdaten")
 
-    return bars
+    return bars[-limit:]
 


### PR DESCRIPTION
## Summary
- add a KuCoin downloader CLI that stores historical XMR/USDT candles in the project format
- switch the live minute feed to KuCoin and prefer downloaded data for simulations
- document how to fetch two years of KuCoin candles for the demo

## Testing
- python -m compileall darkhorse/kucoin.py darkhorse/live.py

------
https://chatgpt.com/codex/tasks/task_e_68d50b743534832d859b51f658217702